### PR TITLE
Assemblies now formatted and pushed to database. Updated some databas…

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -64,6 +64,15 @@ process {
             mode: 'copy'
         ]
     }
+    withName: FORMAT_ASSEMBLY {
+        container = 'public.ecr.aws/o8h2f0o1/bigbacter-base:1.0'
+        ext.args = ''
+        publishDir = [
+            path: { "${params.outdir}/" },
+            pattern: "none",
+            mode: 'copy'
+        ]
+    }
     withName: POPPUNK_ASSIGN {
         container = 'public.ecr.aws/o8h2f0o1/poppunk:2.6.5'
         ext.args = '--update-db --run-qc --max-zero-dist 1 --max-merge 0 --max-a-dist 0.5'
@@ -263,6 +272,11 @@ process {
                 pattern: "ref.fa.gz",
                 mode: 'copy',
                 overwrite: false
+            ],
+            [
+                path: { "${params.db}/${taxa}/clusters/${cluster}/assembly/" },
+                pattern: "*_T*.fa.gz",
+                mode: 'copy'
             ],
         ]
     }

--- a/modules/local/format-input.nf
+++ b/modules/local/format-input.nf
@@ -1,0 +1,21 @@
+process FORMAT_ASSEMBLY {
+    tag "${sample}"
+    label 'process_low'
+
+    input:
+    tuple val(sample), path(assembly)
+
+    output:
+    tuple val(sample), path("${sample}.fa.gz", includeInputs: true), emit: assembly
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    shell:
+    '''
+    # compress assembly file - ignore if already compressed
+    gzip !{assembly} || true
+    # rename file, if needed
+    mv -n * "!{sample}.fa.gz"
+    '''
+}

--- a/modules/local/push-files.nf
+++ b/modules/local/push-files.nf
@@ -3,11 +3,10 @@ process PUSH_CLUSTER_FILES {
     label 'process_low'
 
     input:
-    tuple val(taxa), val(cluster), path(ref), path(new_snippy)
+    tuple val(taxa), val(cluster), path(ref), path(new_snippy), path(assembly)
 
     output:
-    path 'ref.fa.gz'
-    path new_snippy, emit: cluster_files
+    tuple path(new_snippy), path(assembly), path('ref.fa.gz'), emit: cluster_files
     
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/seqtk_seq.nf
+++ b/modules/local/seqtk_seq.nf
@@ -20,7 +20,7 @@ process SEQTK_SEQ {
 
     script:
     args = task.ext.args ?: ''
-    prefix = task.ext.prefix ?: "${timestamp}-${sample}"
+    prefix = task.ext.prefix ?: sample
     """
     seqtk \\
         seq \\

--- a/subworkflows/local/push_files.nf
+++ b/subworkflows/local/push_files.nf
@@ -7,7 +7,7 @@ include { PUSH_TAXA_FILES    } from '../../modules/local/push-files'
 
 workflow PUSH_FILES {
     take:
-    new_cluster_files // channel: [taxa, cluster, ref, new_snippy, sketch]
+    new_cluster_files // channel: [taxa, cluster, ref, new_snippy, assembly]
     new_taxa_files    // channel: [taxa, new_pp_db]
 
     main:


### PR DESCRIPTION
1. Input assemblies are now gzip compressed and renamed to match the input sample name and saved to the BigBacter database. This is in preparation for future development.
2. Assembly files are included in the database summary function.
3. "Next steps" are provided when you run BigBacter without '--push true'.
