### PR TITLE
Resolve maxing out concurrent NCBI API calls

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -27,7 +27,7 @@ process {
     }
     withName: NCBI_DATASETS {
         container = 'public.ecr.aws/o8h2f0o1/ncbi-datasets:16.15.0'
-        maxForks = params.ncbi_max_concurrent ?: 1
+        maxForks = 1
         beforeScript = 'sleep $((RANDOM % 10 + 5))'
         publishDir = [
             path: { "${params.outdir}/" },
@@ -37,7 +37,7 @@ process {
     }
     withName: FASTERQDUMP {
         ext.args = '-S'
-        maxForks = params.ncbi_max_concurrent ?: 2
+        maxForks = 2
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -27,7 +27,7 @@ process {
     }
     withName: NCBI_DATASETS {
         container = 'public.ecr.aws/o8h2f0o1/ncbi-datasets:16.15.0'
-        maxForks = params.ncbi_max_concurrent ?: 3
+        maxForks = params.ncbi_max_concurrent ?: 2
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",
@@ -36,7 +36,7 @@ process {
     }
     withName: FASTERQDUMP {
         ext.args = '-S'
-        maxForks = params.ncbi_max_concurrent ?: 3
+        maxForks = params.ncbi_max_concurrent ?: 2
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -27,7 +27,7 @@ process {
     }
     withName: NCBI_DATASETS {
         container = 'public.ecr.aws/o8h2f0o1/ncbi-datasets:16.15.0'
-        maxForks = params.ncbi_max_concurrent
+        maxForks = params.ncbi_max_concurrent ?: 3
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",
@@ -36,7 +36,7 @@ process {
     }
     withName: FASTERQDUMP {
         ext.args = '-S'
-        maxForks = params.ncbi_max_concurrent
+        maxForks = params.ncbi_max_concurrent ?: 3
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -175,7 +175,7 @@ process {
     }
     withName: IQTREE {
         container = 'public.ecr.aws/o8h2f0o1/iqtree2:2.3.4'
-        ext.args = '-m GTR+I+G'
+        ext.args = '-m GTR+I+G -czb'
         publishDir = [
             path: { "${params.outdir}/${timestamp}/${taxa}/${cluster}/trees" },
             pattern: "*.nwk",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -27,7 +27,8 @@ process {
     }
     withName: NCBI_DATASETS {
         container = 'public.ecr.aws/o8h2f0o1/ncbi-datasets:16.15.0'
-        maxForks = params.ncbi_max_concurrent ?: 2
+        maxForks = params.ncbi_max_concurrent ?: 1
+        beforeScript = 'sleep $((RANDOM % 10 + 5))'
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -172,7 +172,7 @@ process {
     }
     withName: IQTREE {
         container = 'public.ecr.aws/o8h2f0o1/iqtree2:2.3.4'
-        ext.args = '-m GTR+I+G -czb'
+        ext.args = '-m GTR+I+G'
         publishDir = [
             path: { "${params.outdir}/${timestamp}/${taxa}/${cluster}/trees" },
             pattern: "*.nwk",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -27,6 +27,7 @@ process {
     }
     withName: NCBI_DATASETS {
         container = 'public.ecr.aws/o8h2f0o1/ncbi-datasets:16.15.0'
+        maxForks = params.ncbi_max_concurrent
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",
@@ -35,6 +36,7 @@ process {
     }
     withName: FASTERQDUMP {
         ext.args = '-S'
+        maxForks = params.ncbi_max_concurrent
         publishDir = [
             path: { "${params.outdir}/" },
             pattern: "none",

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,7 +50,7 @@ params {
     run_id                     = null
 
     // NCBI download options
-    ncbi_max_concurrent        = 3
+    ncbi_max_concurrent        = 2
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,6 +49,9 @@ params {
     resolve_merged             = true
     run_id                     = null
 
+    // NCBI download options
+    ncbi_max_concurrent        = 3
+
     // MultiQC options
     multiqc_config             = null
     multiqc_title              = null
@@ -69,7 +72,7 @@ params {
     version                    = false
     validate_params            = true
     show_hidden_params         = false
-    schema_ignore_params       = 'genomes,input,ncbi'
+    schema_ignore_params       = 'genomes,input,ncbi,ncbi_max_concurrent'
 
 
     // Config options

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,8 +49,6 @@ params {
     resolve_merged             = true
     run_id                     = null
 
-    // NCBI download options
-    ncbi_max_concurrent        = 1
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
     read_qc                   = true
     assembly_qc               = true
     min_contig_len            = 300
-    
+
     // QC: Clustering
     pp_runqc                  = true
     pp_maxzerodist            = 0.05
@@ -72,7 +72,7 @@ params {
     version                    = false
     validate_params            = true
     show_hidden_params         = false
-    schema_ignore_params       = 'genomes,input,ncbi,ncbi_max_concurrent'
+    schema_ignore_params       = 'genomes,input,ncbi'
 
 
     // Config options

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,7 +50,7 @@ params {
     run_id                     = null
 
     // NCBI download options
-    ncbi_max_concurrent        = 2
+    ncbi_max_concurrent        = 1
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -215,6 +215,15 @@
                 "run_id": {
                     "fa_icon": "fas fa-skull-crossbones",
                     "description": "Run ID. This will bypass the epoch timestamp. Only change if you know what you are doing."
+                },
+                "ncbi_max_concurrent": {
+                    "type": "integer",
+                    "default": 3,
+                    "minimum": 1,
+                    "maximum": 10,
+                    "fa_icon": "fas fa-download",
+                    "description": "Maximum number of concurrent downloads from NCBI. Reducing this value helps avoid NCBI rate limiting (429 errors).",
+                    "help_text": "NCBI has rate limits on API requests. Setting this too high (>3) may result in '429 Too Many Requests' errors. Setting it to 1-2 is recommended for reliability."
                 }
             },
             "fa_icon": "fas fa-terminal"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -218,7 +218,7 @@
                 },
                 "ncbi_max_concurrent": {
                     "type": "integer",
-                    "default": 3,
+                    "default": 2,
                     "minimum": 1,
                     "maximum": 10,
                     "fa_icon": "fas fa-download",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -218,12 +218,12 @@
                 },
                 "ncbi_max_concurrent": {
                     "type": "integer",
-                    "default": 2,
+                    "default": 1,
                     "minimum": 1,
-                    "maximum": 10,
+                    "maximum": 5,
                     "fa_icon": "fas fa-download",
                     "description": "Maximum number of concurrent downloads from NCBI. Reducing this value helps avoid NCBI rate limiting (429 errors).",
-                    "help_text": "NCBI has rate limits on API requests. Setting this too high (>3) may result in '429 Too Many Requests' errors. Setting it to 1-2 is recommended for reliability."
+                    "help_text": "NCBI has rate limits on API requests. Setting this too high (>3) may result in '429 Too Many Requests' errors. Setting it to 1-2 is recommended for reliability but maybe raised to 5 with an NCBI API"
                 }
             },
             "fa_icon": "fas fa-terminal"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -215,15 +215,6 @@
                 "run_id": {
                     "fa_icon": "fas fa-skull-crossbones",
                     "description": "Run ID. This will bypass the epoch timestamp. Only change if you know what you are doing."
-                },
-                "ncbi_max_concurrent": {
-                    "type": "integer",
-                    "default": 1,
-                    "minimum": 1,
-                    "maximum": 5,
-                    "fa_icon": "fas fa-download",
-                    "description": "Maximum number of concurrent downloads from NCBI. Reducing this value helps avoid NCBI rate limiting (429 errors).",
-                    "help_text": "NCBI has rate limits on API requests. Setting this too high (>3) may result in '429 Too Many Requests' errors. Setting it to 1-2 is recommended for reliability but maybe raised to 5 with an NCBI API"
                 }
             },
             "fa_icon": "fas fa-terminal"


### PR DESCRIPTION
<!--
# nf-core/bigbacter pull request
I added in a limitation to the maximum number of concurrent processes that use NCBI API can be used at one as the maximum allowed by ncbi in total is 3 without an NCBI API key
-->

## PR checklist

- [ X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bigbacter/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bigbacter _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
