### PR TITLE
Countfastq try

### DIFF
--- a/subworkflows/local/prepare/main.nf
+++ b/subworkflows/local/prepare/main.nf
@@ -75,7 +75,7 @@ workflow PREPARE {
                     read_count = reads[0].countFastq() * 2
                 } catch (Exception e) {
                     log.warn "${meta.id}: Failed to count reads - will attempt downsampling anyway!"
-                    read_count = params.max_reads
+                    read_count = params.max_reads + 1
                 }
                 [meta: meta, reads: reads, n: read_count]
             }

--- a/subworkflows/local/prepare/main.nf
+++ b/subworkflows/local/prepare/main.nf
@@ -70,7 +70,13 @@ workflow PREPARE {
     if (params.max_reads) {
         ch_reads
             .map { meta, reads ->
-                def read_count = reads[0].countFastq() * 2
+                def read_count
+                try {
+                    read_count = reads[0].countFastq() * 2
+                } catch (Exception e) {
+                    log.warn "${meta.id}: Failed to count reads - will attempt downsampling anyway!"
+                    read_count = params.max_reads
+                }
                 [meta: meta, reads: reads, n: read_count]
             }
             .branch {


### PR DESCRIPTION
Failure observed when trying to count a FASTQ file in Seqera Cloud. This behavior could not be replicated locally using the same nextflow version (26.04.3). The workflow now _tries_ to count reads in a FASTQ and if it fails, it defaults to trying to downsample automatically. If no downsampling is needed, then there is no impact other than the seqtk sample process being run. 