### PR TITLE
include option to keep snippy bam file

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -70,7 +70,7 @@ process {
   }
   withName: 'SNIPPY_SINGLE' {
     container  = 'public.ecr.aws/o8h2f0o1/snippy:4.6.0-SC2'
-    ext.args   = '--cleanup'
+    ext.args   = ''
     publishDir = [ path: { "${params.outdir}/${meta.timestamp}/${meta.taxa}/${meta.cluster}/var" }, pattern: "*.tar.gz", mode: 'copy' ]
   }
   withName: 'SNIPPY_CORE' {

--- a/modules/local/snippy/single/main.nf
+++ b/modules/local/snippy/single/main.nf
@@ -19,6 +19,7 @@ process SNIPPY_SINGLE {
     asm_gz_arg    = reads ? "" : "gzip -d ${assembly}"
     reads_arg     = reads ? "--R1 ${reads[0]} --R2 ${reads[1]}" : "--ctgs ${assembly.baseName}"
     subsample_arg = reads ? "--subsample ${downsample_rate}" : ""
+    cleanup_arg   = params.keep_bam ? "" : "--cleanup"
     
     """
     # extract reference
@@ -34,6 +35,7 @@ process SNIPPY_SINGLE {
         ${subsample_arg} \\
         --outdir ${meta.id} \\
         --cpus ${task.cpus} \\
+        ${cleanup_arg} \\
         ${args}
 
     # compress output

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,9 +51,10 @@ params {
     // -------------------------------
     // Variant calling
     // -------------------------------
-    min_genome_fraction        = 0.8  // Minimum genome fraction for a sample to be included in the core genome analysis
-    min_core_fraction          = 0.9  // Minimum core genome fraction for a reference site to be included in the core genome analysis
-    mask_recomb                = true // Perform recombination masking, in addition to standard variant detection
+    min_genome_fraction        = 0.8   // Minimum genome fraction for a sample to be included in the core genome analysis
+    min_core_fraction          = 0.9   // Minimum core genome fraction for a reference site to be included in the core genome analysis
+    mask_recomb                = true  // Perform recombination masking, in addition to standard variant detection
+    keep_bam                   = false // Keep the bam file created during variant calling. Will dramatically increase the database size.
 
     // -------------------------------
     // Phylogenetic analysis

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -102,8 +102,8 @@
         }
       }
     },
-    "new_group_1": {
-      "title": "New Group 1",
+    "clustering_options": {
+      "title": "Clustering Options",
       "type": "object",
       "description": "",
       "default": "",
@@ -198,6 +198,12 @@
           "default": true,
           "description": "Perform recombination masking, in addition to standard variant detection",
           "fa_icon": "fas fa-chart-pie"
+        },
+        "keep_bam": {
+          "type": "boolean",
+          "default": false,
+          "description": "Keep the bam file created during variant calling. Will dramatically increase the database size.",
+          "fa_icon": "fas fa-users-cog"
         }
       }
     },
@@ -409,7 +415,7 @@
       "$ref": "#/$defs/assets"
     },
     {
-      "$ref": "#/$defs/new_group_1"
+      "$ref": "#/$defs/clustering_options"
     },
     {
       "$ref": "#/$defs/reference_selection"


### PR DESCRIPTION
Added `--keep_bam` option that will retain the bam file created by Snippy. This can dramatically increase the database size.
