### PR TITLE
fix microreact and run summary showing up in Seqera output tab

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -107,7 +107,7 @@ process {
       [ pattern: '*.nwk',         path: { "${params.outdir}/${meta.timestamp}/${meta.taxa}/${meta.cluster}/tree" } ],
       [ pattern: '*_summary.*',   path: { "${params.outdir}/${meta.timestamp}/${meta.taxa}/${meta.cluster}/summary" } ],
       [ pattern: '*-dist-*',      path: { "${params.outdir}/${meta.timestamp}/${meta.taxa}/${meta.cluster}/dist" } ],
-      [ pattern: '*.microreact',  path: { "${params.outdir}/${meta.timestamp}/${meta.taxa}/${meta.cluster}/reports" } ]
+      [ pattern: '*.microreact',  path: { "${params.outdir}/${meta.timestamp}/${meta.taxa}/${meta.cluster}/report" } ]
     ]
   }
 

--- a/tower.yml
+++ b/tower.yml
@@ -1,6 +1,6 @@
 reports:
   "**/summary/*":
-    display: "Summarry file (cluster)"
+    display: "Summary file (cluster)"
   "**/report/*":
     display: "Microreact report (cluster)"
   "**/aln/*":
@@ -21,3 +21,6 @@ reports:
     display: "MultiQC report (run)"
   "**/pipeline_info/*":
     display: "Pipeline info (run)"
+  "*/*/*-summary.csv":
+    display: "Run summary (run)"
+    


### PR DESCRIPTION
-Fixed spelling error in Seqera file output report name: Summarry --> Summary
-Fixed microreact output to /report instead of /reports so now microreact files populate the Seqera outputs tab correctly
-Added run-summary.csv to tower.yml